### PR TITLE
WidgetPageBuilder (arguments:dynamic) parameter becomes (settings:RouteSettings)

### DIFF
--- a/example/app2/lib/example_external.dart
+++ b/example/app2/lib/example_external.dart
@@ -12,26 +12,25 @@ class MicroApplication2 extends MicroApp {
   @override
   List<MicroAppPage> get pages => [
         MicroAppPage(
-            route: baseRoute.baseRoute.route,
+            route: baseRoute.microAppNavigator,
             pageBuilder: PageBuilder(
-              builder: (context, arguments) => MicroAppNavigatorWidget(
+              builder: (_, __) => MicroAppNavigatorWidget(
                   microBaseRoute: baseRoute,
                   initialRoute: Application2Routes().page1),
               transitionType: MicroPageTransitionType.rippleLeftDown,
             )),
         MicroAppPage(
             route: baseRoute.page1,
-            pageBuilder:
-                PageBuilder(builder: (context, arguments) => const Page1())),
+            pageBuilder: PageBuilder(builder: (_, settings) => const Page1())),
         MicroAppPage(
           route: baseRoute.page2,
-          pageBuilder:
-              PageBuilder(builder: (context, arguments) => const Page2()),
+          pageBuilder: PageBuilder(
+              builder: (_, settings) =>
+                  Page2(title: settings.arguments as String?)),
         ),
         MicroAppPage(
             route: baseRoute.page3,
-            pageBuilder:
-                PageBuilder(builder: (context, arguments) => const Page3())),
+            pageBuilder: PageBuilder(builder: (_, __) => const Page3())),
         MicroAppPage(
             route: baseRoute.pageColors,
             pageBuilder:

--- a/example/app2/lib/pages/page1.dart
+++ b/example/app2/lib/pages/page1.dart
@@ -2,8 +2,23 @@ import 'package:example_routes/routes/application2_routes.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_micro_app/flutter_micro_app.dart';
 
-class Page1 extends StatelessWidget {
+class Page1 extends StatefulWidget {
   const Page1({Key? key}) : super(key: key);
+
+  @override
+  State<Page1> createState() => _Page1State();
+}
+
+class _Page1State extends State<Page1> {
+  @override
+  void initState() {
+    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
+      debugPrint(
+          'Nested InitialRouteSettings: ${MicroAppNavigator.getInitialRouteSettings(context).toString()}');
+    });
+
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +40,8 @@ class Page1 extends StatelessWidget {
             ElevatedButton(
               child: const Text('Open page2'),
               onPressed: () {
-                context.maNav.pushNamed(Application2Routes().page2);
+                context.maNav.pushNamed(Application2Routes().page2,
+                    arguments: 'Title Page 2');
               },
             ),
             ElevatedButton(

--- a/example/app2/lib/pages/page2.dart
+++ b/example/app2/lib/pages/page2.dart
@@ -3,13 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_micro_app/flutter_micro_app.dart';
 
 class Page2 extends StatelessWidget {
-  const Page2({Key? key}) : super(key: key);
+  final String? title;
+  const Page2({this.title, Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Page 2'),
+        title: Text(title ?? 'Page 2'),
       ),
       body: Container(
         alignment: Alignment.center,

--- a/example/app2/pubspec.lock
+++ b/example/app2/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.6.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/example_host/lib/main.dart
+++ b/example/example_host/lib/main.dart
@@ -149,10 +149,11 @@ class _BaseHomePageState extends State<BaseHomePage> {
                       height: 8,
                     ),
                     ElevatedButton(
-                      child: const Text('Open Application2(package)'),
+                      child: const Text('Open Nested MicroAppNavigator'),
                       onPressed: () {
-                        context.maNav
-                            .pushNamed(Application2Routes().baseRoute.route);
+                        context.maNav.pushNamed(
+                            Application2Routes().microAppNavigator,
+                            arguments: 'microAppNavigator argument');
                       },
                     ),
                     const SizedBox(

--- a/example/example_routes/lib/routes/application2_routes.dart
+++ b/example/example_routes/lib/routes/application2_routes.dart
@@ -4,6 +4,7 @@ class Application2Routes extends MicroAppBaseRoute {
   @override
   MicroAppRoute get baseRoute => MicroAppRoute('example_external');
 
+  String get microAppNavigator => path(['microAppNavigator']);
   String get page1 => path(['page1']);
   String get page2 => path(['page2']);
   String get page3 => path(['page3']);

--- a/lib/src/controllers/navigators/navigator_controller.dart
+++ b/lib/src/controllers/navigators/navigator_controller.dart
@@ -47,7 +47,9 @@ class MicroAppNavigatorController extends RouteObserver<PageRoute<dynamic>> {
   /// [getPageWidget]
   Widget getPageWidget(String route, BuildContext context,
           {Object? arguments, String? type, Widget? orElse}) =>
-      getPageBuilder(route)?.builder.call(context, arguments) ??
+      getPageBuilder(route)
+          ?.builder
+          .call(context, RouteSettings(arguments: arguments, name: route)) ??
       orElse ??
       const SizedBox.shrink();
 
@@ -191,15 +193,19 @@ class MicroAppNavigatorController extends RouteObserver<PageRoute<dynamic>> {
 
     if (transitionType != MicroPageTransitionType.platform) {
       return MicroPageTransition(
-          pageBuilder: pageBuilder.builder, type: transitionType);
+          settings: RouteSettings(arguments: routeArguments, name: routeName),
+          pageBuilder: pageBuilder.builder,
+          type: transitionType);
     } else {
       if (isIOS) {
         return CupertinoPageRoute(
-          builder: (context) => pageBuilder.builder(context, routeArguments),
+          builder: (context) => pageBuilder.builder(context,
+              RouteSettings(arguments: routeArguments, name: routeName)),
         );
       } else {
         return MaterialPageRoute(
-          builder: (context) => pageBuilder.builder(context, routeArguments),
+          builder: (context) => pageBuilder.builder(context,
+              RouteSettings(arguments: routeArguments, name: routeName)),
         );
       }
     }

--- a/lib/src/presentation/pages/page_transition/micro_page_transition.dart
+++ b/lib/src/presentation/pages/page_transition/micro_page_transition.dart
@@ -47,7 +47,12 @@ class MicroPageTransition<T> extends PageRouteBuilder<T> {
         super(
           pageBuilder: (BuildContext context, Animation<double> animation,
               Animation<double> secondaryAnimation) {
-            Widget child = pageBuilder(context, settings?.arguments);
+            Widget child = pageBuilder(
+                context,
+                RouteSettings(
+                  name: settings?.name,
+                  arguments: settings?.arguments,
+                ));
             return inheritTheme
                 ? InheritedTheme.captureAll(
                     context,

--- a/lib/src/presentation/widgets/micro_navigator_widget.dart
+++ b/lib/src/presentation/widgets/micro_navigator_widget.dart
@@ -44,6 +44,15 @@ class MicroAppNavigatorWidget extends StatefulWidget {
 
 class _MicroAppNavigatorWidgetState extends State<MicroAppNavigatorWidget>
     with RouterGenerator {
+  RouteSettings? initialSettings;
+
+  @override
+  void initState() {
+    WidgetsBinding.instance?.addPostFrameCallback(
+        (timeStamp) => initialSettings = ModalRoute.of(context)?.settings);
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
     return MicroAppNavigator(
@@ -71,6 +80,10 @@ class _MicroAppNavigatorWidgetState extends State<MicroAppNavigatorWidget>
 }
 
 class MicroAppNavigator extends Navigator {
+  static Object? getInitialRouteSettings(BuildContext context) => context
+      .findAncestorStateOfType<_MicroAppNavigatorWidgetState>()
+      ?.initialSettings;
+
   final MicroAppBaseRoute microBaseRoute;
   final bool closeOnPopFirstPage;
 

--- a/lib/src/utils/typedefs.dart
+++ b/lib/src/utils/typedefs.dart
@@ -7,7 +7,7 @@ import '../controllers/overlay/micro_overlay_controller.dart';
 import '../entities/events/micro_app_event.dart';
 
 typedef WidgetPageBuilder = Widget Function(
-    BuildContext context, dynamic arguments);
+    BuildContext context, RouteSettings settings);
 typedef MethodCallHandler = Future<dynamic> Function(MethodCall);
 typedef MicroAppEventOnEvent = void Function(MicroAppEvent);
 typedef MicroAppEventOnDone = void Function();


### PR DESCRIPTION
### Summary (Feature / Bugfix description)

- WidgetPageBuilder (arguments:dynamic) parameter becomes (settings:RouteSettings)
- Add getInitialRouteSettings in order to get initial RouteSettings of nested MicroAppNavigator

#### This PR fixes/implements (types of changes)
- [x] Breaking change