### PR TITLE
Using Map as default data transfer object, instead string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.8.0
+[2022-05-22]
+
+#### Break
+- Using Map as default data transfer object, instead string
+
+#### Fix
+- Enable/disable native requets in navigation events
+
+#### Added
+- Parses event data from native platform
+
 ## 0.7.0
 [2022-05-03]
 #### Break

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 ![Screen Shot 2022-02-03 at 00 32 35](https://user-images.githubusercontent.com/3827308/152278448-3c63a692-f390-4377-964b-6f2c447c0a70.png)
 
-[coming soon]  This diagram shows up the initial proposal about layers, their relationships and dependencies.
 
 ### ⛵️ Navigation between pages
 #### Use [NavigatorInstance] to navigate between pages
@@ -216,7 +215,7 @@ MicroAppEventController()
 ```
 
 > **Note**
-> ❕ Use Json String for agnostic platform purposes, or HashMap for Kotlin, Dictionary for Swift or java.util.HashMap for Java
+> Use Json String for agnostic platform purposes, or HashMap for Kotlin, Dictionary for Swift or java.util.HashMap for Java
 
 <details open>
 <summary style="font-size:14px"> Dispatching event from native, using Json</summary>
@@ -228,7 +227,7 @@ MicroAppEventController()
  "distinct": true, // Optional
  "channels": [], // Optional
  "version": "1.0.0", // Optional
- "timestamp": "2020-01-01T00:00:00.000Z" // Optional
+ "datetime": "2020-01-01T00:00:00.000Z" // Optional
 }
 ```
 </details>
@@ -246,7 +245,7 @@ arguments["payload"] = payload
 arguments["distinct"] = true
 arguments["channels"] = listOf("abc", "chatbot")
 arguments["version"] = "1.0.0"
-arguments["timestamp"] = "2020-01-01T00:00:00.000Z"
+arguments["datetime"] = "2020-01-01T00:00:00.000Z"
 
 appEventChannelMessenger.invokeMethod("app_event", arguments)
 ```

--- a/README.md
+++ b/README.md
@@ -215,6 +215,45 @@ MicroAppEventController()
     );
 ```
 
+> **Note**
+> ❕ Use Json String for agnostic platform purposes, or HashMap for Kotlin, Dictionary for Swift or java.util.HashMap for Java
+
+<details open>
+<summary style="font-size:14px"> Dispatching event from native, using Json</summary>
+
+```json
+{
+ "name": "", // Required
+ "payload": {}, // Optional
+ "distinct": true, // Optional
+ "channels": [], // Optional
+ "version": "1.0.0", // Optional
+ "timestamp": "2020-01-01T00:00:00.000Z" // Optional
+}
+```
+</details>
+
+<details open>
+<summary style="font-size:14px"> Dispatching event from native(Android), using Kotlin</summary>
+
+```kotlin
+val payload: MutableMap<String, Any> = HashMap()
+payload["platform"] = "Android"
+
+val arguments: MutableMap<String, Any> = HashMap()
+arguments["name"] = "event_from_native"
+arguments["payload"] = payload
+arguments["distinct"] = true
+arguments["channels"] = listOf("abc", "chatbot")
+arguments["version"] = "1.0.0"
+arguments["timestamp"] = "2020-01-01T00:00:00.000Z"
+
+appEventChannelMessenger.invokeMethod("app_event", arguments)
+```
+</details>
+
+
+
 #### 🌐 It is possible to wait for other micro apps to respond to the event you issued, but make sure someone else will respond to your event, otherwise you will wait forever 😢
 
 `.getFirstResult()` will return the first response(fastest) among all micro apps that eventually can respond to this same  event.  
@@ -243,6 +282,30 @@ event.resultError(['error message by Barry Allen', 'my bad 🤦']);
 
 // Who will respond faster? native? flutter?
 // If you don't want to take that risk, just deal with the List<Future> response.
+```
+
+**Dealing with errors and timeout:**
+```dart
+try {
+  final result = await MicroAppEventController()
+      .emit(MicroAppEvent<String>(
+        name: 'event_from_flutter',
+        payload: 'My payload',
+      ))
+      .getFirstResult()
+      .timeout(const Duration(seconds: 1));
+  logger.d('Result is: $result');
+} on TimeoutException catch (e) {
+  logger.e(
+      'The native platform did not respond to the request',
+      error: e);
+} on PlatformException catch (e) {
+  logger.e(
+      'The native platform respond to the request with some error',
+      error: e);
+} on Exception {
+  logger.e('Generic Error');
+}
 ```
 
 #### 🦻 Listen to events (MicroApp)s

--- a/example/app2/lib/example_external.dart
+++ b/example/app2/lib/example_external.dart
@@ -41,7 +41,7 @@ class MicroApplication2 extends MicroApp {
   MicroAppEventHandler? get microAppEventHandler =>
       MicroAppEventHandler((data) {
         logger.d([
-          '(MicroAppExampleExternal) ALSO received here! :',
+          '(MicroAppExampleExternal - No channels) received here! :',
           data.name,
           data.payload
         ]);

--- a/example/app2/pubspec.lock
+++ b/example/app2/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -109,6 +109,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -169,7 +176,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/example/example_host/android/app/src/main/kotlin/com/example/example/MainActivity.kt
+++ b/example/example_host/android/app/src/main/kotlin/com/example/example/MainActivity.kt
@@ -20,10 +20,52 @@ class MainActivity: FlutterActivity() {
         val routerChannelMessenger =
             MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL_ROUTER_COMMAND)
 
+        val appEventChannelMessenger =
+            MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL_MICRO_APP)
+
         MethodChannel(flutterEngine.dartExecutor,CHANNEL_MICRO_APP).setMethodCallHandler{
                 call,result ->
             when (call.method) {
                 "app_event" -> {
+
+                     if (call.hasArgument("name") && call.argument<String>("name") == "event_from_flutter") {
+                         // Use Json String for agnostic platform purposes, or HashMap for Kotlin, Dictionary for Swift or java.util.HashMap for Java
+
+                             /*
+                             val argumentsAsJsonString = """
+                                {
+                                 "name": "event_from_native",
+                                 "payload": {},
+                                 "distinct": true,
+                                 "channels": [],
+                                 "version": "1.0.0",
+                                 "datetime": "2020-01-01T00:00:00.000Z"
+                                }
+                             """.trimIndent()
+
+                             appEventChannelMessenger.invokeMethod("app_event", argumentsAsJsonString)
+                            */
+
+
+                         
+                         val payload: MutableMap<String, Any> = HashMap()
+                         payload["platform"] = "Android"
+
+                         val arguments: MutableMap<String, Any> = HashMap()
+                         arguments["name"] = "event_from_native"
+                         arguments["payload"] = payload
+                         arguments["distinct"] = true
+                         arguments["channels"] = emptyList<String>()
+                         arguments["version"] = "1.0.0"
+                         arguments["datetime"] = "2020-01-01T00:00:00.000Z"
+
+                         // Send event in other thread to flutter side
+                         appEventChannelMessenger.invokeMethod("app_event", arguments)
+
+                         // Also, respond in the same thread to flutter side
+                         result.success(true)
+                     }
+
                     println("*** Native Android receive (channel: flutter/micro_app/app/events): 'app_event' with arguments: ${call.arguments.toString()} !!")
                 } else -> {
                     println("*** Native Android receive (channel: flutter/micro_app/app/events): ${call.method} with arguments: ${call.arguments.toString()} !!")

--- a/example/example_host/lib/example_micro_app.dart
+++ b/example/example_host/lib/example_micro_app.dart
@@ -9,8 +9,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_micro_app/dependencies.dart';
 import 'package:flutter_micro_app/flutter_micro_app.dart';
 
-// It could be a BLoC, Mobx, Redux, GetX or whatever
-// but for now, it's just the incredible, super `ValueNotifier` :)
 class ColorController extends ValueNotifier<MaterialColor> {
   ColorController([MaterialColor color = Colors.amber]) : super(color);
   void changeColor(MaterialColor color) => value = color;
@@ -56,8 +54,11 @@ class MicroApplication1 extends MicroApp {
             buttonsColorController.changeColor(event.cast());
           }
         }
-        logger.d(
-            ['(MicroAppExample) event received:', event.name, event.payload]);
+        logger.d([
+          '(MicroAppExample - channels(abc, chatbot, colors) event received:',
+          event.name,
+          event.payload
+        ]);
 
         event.resultSuccess('success!!!');
       }, channels: const ['abc', 'chatbot', 'colors']);

--- a/example/example_host/lib/pages/material_app_page_initial.dart
+++ b/example/example_host/lib/pages/material_app_page_initial.dart
@@ -21,6 +21,7 @@ class _MaterialAppPageInitialState extends State<MaterialAppPageInitial>
   @override
   void initState() {
     registerEventHandler(MicroAppEventHandler<String>((event) {
+      ScaffoldMessenger.of(context).removeCurrentSnackBar();
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(
         content: Text(event.cast()),
       ));

--- a/example/example_host/lib/pages/material_app_page_initial.dart
+++ b/example/example_host/lib/pages/material_app_page_initial.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:example_routes/routes/application1_routes.dart';
 import 'package:example_routes/routes/application2_routes.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_micro_app/dependencies.dart';
 import 'package:flutter_micro_app/flutter_micro_app.dart';
 
@@ -142,6 +145,31 @@ class _MaterialAppPageInitialState extends State<MaterialAppPageInitial>
                 onPressed: () {
                   context.maNav.pushNamed(Application1Routes()
                       .pageExample); // There is no [pageExample] inside current MaterialApp
+                },
+              ),
+              ElevatedButton(
+                child: const Text('Receive Native Event'),
+                onPressed: () async {
+                  try {
+                    final result = await MicroAppEventController()
+                        .emit(MicroAppEvent(
+                          name: 'event_from_flutter',
+                          payload: const {'app': 'Flutter'},
+                        ))
+                        .getFirstResult()
+                        .timeout(const Duration(seconds: 1));
+                    logger.d('Result is: $result');
+                  } on TimeoutException catch (e) {
+                    logger.e(
+                        'The native platform did not respond to the request',
+                        error: e);
+                  } on PlatformException catch (e) {
+                    logger.e(
+                        'The native platform respond to the request with some error',
+                        error: e);
+                  } on Exception {
+                    logger.e('Generic Error');
+                  }
                 },
               ),
               MicroAppWidgetBuilder(

--- a/example/example_host/pubspec.lock
+++ b/example/example_host/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.7.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -123,6 +123,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -183,7 +190,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/example/example_routes/pubspec.lock
+++ b/example/example_routes/pubspec.lock
@@ -82,7 +82,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.7.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -102,6 +102,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -162,7 +169,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/controllers/app_event/micro_app_event_controller.dart
+++ b/lib/src/controllers/app_event/micro_app_event_controller.dart
@@ -6,6 +6,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_micro_app/flutter_micro_app.dart';
 import 'package:flutter_micro_app/src/services/native_service.dart';
 
+import '../../infra/adapters/micro_app_event/micro_app_event_adapter.dart';
+import '../../infra/adapters/micro_app_event/micro_app_event_json_adapter.dart';
 import 'micro_app_event_delegate.dart';
 
 /// [MicroAppEventController]
@@ -40,8 +42,10 @@ class MicroAppEventController {
     _handlerRegisterDelegate = MicroAppEventDelegate();
     _microAppNativeService = MicroAppNativeService(_channel,
         methodCallHandler: (MethodCall call) async {
-      _controller
-          .add(MicroAppEvent(name: call.method, payload: call.arguments));
+      MicroAppEventAdapter adapter = MicroAppEventJsonAdapter();
+      final event = adapter.parse(call);
+
+      _controller.add(event);
     });
   }
 

--- a/lib/src/controllers/app_event/micro_app_event_controller.dart
+++ b/lib/src/controllers/app_event/micro_app_event_controller.dart
@@ -44,7 +44,6 @@ class MicroAppEventController {
         methodCallHandler: (MethodCall call) async {
       MicroAppEventAdapter adapter = MicroAppEventJsonAdapter();
       final event = adapter.parse(call);
-
       _controller.add(event);
     });
   }
@@ -60,7 +59,7 @@ class MicroAppEventController {
 
     if (MicroAppPreferences.config.nativeEventsEnabled) {
       final nativeFuture = _microAppNativeService.emit(
-          Constants.methodMicroAppEvent, event.toString());
+          Constants.methodMicroAppEvent, event.toMap());
       futures.add(nativeFuture);
     }
 

--- a/lib/src/controllers/navigators/navigator_event_controller.dart
+++ b/lib/src/controllers/navigators/navigator_event_controller.dart
@@ -56,14 +56,14 @@ class MicroAppNavigatorEventController {
   MicroAppNavigatorEventController() {
     _nativeLoggerService = MicroAppNativeService(_channelRouterLogger,
         methodCallHandler: (MethodCall call) async {
-      if (MicroAppPreferences.config.nativeEventsEnabled) {
+      if (MicroAppPreferences.config.nativeNavigationLogEnabled) {
         _nativeLoggerController.add(call);
       }
     });
 
     _nativeCommandService = MicroAppNativeService(_channelRouterCommand,
         methodCallHandler: (MethodCall call) async {
-      if (MicroAppPreferences.config.nativeEventsEnabled) {
+      if (MicroAppPreferences.config.nativeNavigationCommandEnabled) {
         _nativeCommandController.add(call);
       }
     });

--- a/lib/src/entities/events/micro_app_event.dart
+++ b/lib/src/entities/events/micro_app_event.dart
@@ -51,7 +51,8 @@ class MicroAppEvent<T> extends EventChannelsEquatable {
         'payload': payload,
         'channels': channels,
         'distinct': distinct,
-        'methodCall': methodCall.toString(),
+        'methodCall':
+            methodCall.toString() != 'null' ? methodCall.toString() : null,
         'version': version,
         'timestamp': timestamp.toIso8601String()
       });

--- a/lib/src/entities/events/micro_app_event.dart
+++ b/lib/src/entities/events/micro_app_event.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:dart_log/dart_log.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter/services.dart';
 
 /// Event channels
 abstract class EventChannelsEquatable extends Equatable {
@@ -14,15 +16,24 @@ class MicroAppEvent<T> extends EventChannelsEquatable {
   final String name;
   final T? payload;
   final bool distinct;
+  final MethodCall? methodCall;
+  final String? version;
+  final DateTime timestamp;
   final Completer _completer = Completer();
 
-  // ignore: prefer_const_constructors_in_immutables
   MicroAppEvent({
+    List<String> channels = const [],
+    DateTime? timestamp,
     required this.name,
     this.payload,
-    List<String> channels = const [],
     this.distinct = true,
-  }) : super(channels);
+    this.methodCall,
+    this.version,
+  })  : timestamp = timestamp ?? DateTime.now(),
+        super(channels);
+
+  // Verify if the event's origin is a [MethodCall]
+  bool get hasMethodCall => methodCall != null;
 
   T? cast() {
     try {
@@ -35,52 +46,37 @@ class MicroAppEvent<T> extends EventChannelsEquatable {
   @override
   String toString() {
     try {
-      return jsonEncode(toMap());
+      return jsonEncode({
+        'name': name,
+        'payload': payload,
+        'channels': channels,
+        'distinct': distinct,
+        'methodCall': methodCall.toString(),
+        'version': version,
+        'timestamp': timestamp.toIso8601String()
+      });
     } catch (e) {
       return super.toString();
     }
   }
 
-  /// [MicroAppEvent.fromJson(json)]
-  static MicroAppEvent? fromJson(String json) {
-    try {
-      final map = jsonDecode(json);
-      final name = map['name'];
-      final payload = map['payload'];
-      final distinct = map['distinct'];
-      List<dynamic>? list = map['channels'];
-      final channels =
-          list != null ? list.map((e) => e.toString()).toList() : <String>[];
-      return MicroAppEvent(
-        name: name,
-        payload: payload,
-        channels: channels,
-        distinct: distinct,
-      );
-    } catch (e) {
-      return null;
-    }
-  }
-
-  /// [toMap]
-  Map<String, dynamic> toMap() => {
-        'name': name,
-        'payload': payload,
-        'channels': channels,
-        'distinct': distinct,
-      };
-
   /// [MicroAppEvent.copyWith]
   MicroAppEvent<T> copyWith({
     String? name,
     T? payload,
-    List<String>? channels,
+    bool? distinct,
+    MethodCall? methodCall,
+    String? version,
+    DateTime? timestamp,
   }) {
     return MicroAppEvent<T>(
         name: name ?? this.name,
         payload: payload ?? this.payload,
-        channels: channels ?? this.channels,
-        distinct: distinct);
+        distinct: distinct ?? this.distinct,
+        methodCall: methodCall ?? this.methodCall,
+        version: version ?? this.version,
+        timestamp: timestamp ?? this.timestamp,
+        channels: channels);
   }
 
   Type get type => payload.runtimeType;
@@ -98,5 +94,43 @@ class MicroAppEvent<T> extends EventChannelsEquatable {
   Future get asFuture => _completer.future;
 
   @override
-  List<Object?> get props => [name, payload, channels];
+  List<Object?> get props =>
+      [name, payload, channels, distinct, hasMethodCall, version];
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'payload': payload,
+      'channels': channels,
+      'distinct': distinct,
+      'version': version,
+      'timestamp': timestamp.toIso8601String(),
+    };
+  }
+
+  factory MicroAppEvent.fromMap(Map<String, dynamic> map) {
+    List<dynamic>? list = map['channels'];
+    final channels =
+        list != null ? list.map((e) => e.toString()).toList() : <String>[];
+
+    return MicroAppEvent<T>(
+      name: map['name'] ?? '',
+      payload: map['payload'],
+      distinct: map['distinct'] ?? false,
+      version: map['version'],
+      timestamp: DateTime.tryParse(map['timestamp'] ?? '') ?? DateTime.now(),
+      channels: channels,
+    );
+  }
+
+  String toJson() => json.encode(toMap());
+
+  static MicroAppEvent? fromJson(String source) {
+    try {
+      return MicroAppEvent.fromMap(json.decode(source));
+    } catch (e) {
+      logger.e('[MicroAppEvent]: error parsing json', error: e);
+      return null;
+    }
+  }
 }

--- a/lib/src/entities/events/micro_app_event.dart
+++ b/lib/src/entities/events/micro_app_event.dart
@@ -18,18 +18,18 @@ class MicroAppEvent<T> extends EventChannelsEquatable {
   final bool distinct;
   final MethodCall? methodCall;
   final String? version;
-  final DateTime timestamp;
+  final DateTime datetime;
   final Completer _completer = Completer();
 
   MicroAppEvent({
     List<String> channels = const [],
-    DateTime? timestamp,
+    DateTime? datetime,
     required this.name,
     this.payload,
     this.distinct = true,
     this.methodCall,
     this.version,
-  })  : timestamp = timestamp ?? DateTime.now(),
+  })  : datetime = datetime ?? DateTime.now(),
         super(channels);
 
   // Verify if the event's origin is a [MethodCall]
@@ -48,13 +48,13 @@ class MicroAppEvent<T> extends EventChannelsEquatable {
     try {
       return jsonEncode({
         'name': name,
-        'payload': payload,
+        'payload': payload?.toString(),
         'channels': channels,
         'distinct': distinct,
         'methodCall':
             methodCall.toString() != 'null' ? methodCall.toString() : null,
         'version': version,
-        'timestamp': timestamp.toIso8601String()
+        'datetime': datetime.toIso8601String()
       });
     } catch (e) {
       return super.toString();
@@ -68,7 +68,7 @@ class MicroAppEvent<T> extends EventChannelsEquatable {
     bool? distinct,
     MethodCall? methodCall,
     String? version,
-    DateTime? timestamp,
+    DateTime? datetime,
   }) {
     return MicroAppEvent<T>(
         name: name ?? this.name,
@@ -76,7 +76,7 @@ class MicroAppEvent<T> extends EventChannelsEquatable {
         distinct: distinct ?? this.distinct,
         methodCall: methodCall ?? this.methodCall,
         version: version ?? this.version,
-        timestamp: timestamp ?? this.timestamp,
+        datetime: datetime ?? this.datetime,
         channels: channels);
   }
 
@@ -101,11 +101,11 @@ class MicroAppEvent<T> extends EventChannelsEquatable {
   Map<String, dynamic> toMap() {
     return {
       'name': name,
-      'payload': payload,
+      'payload': payload?.toString(),
       'channels': channels,
       'distinct': distinct,
       'version': version,
-      'timestamp': timestamp.toIso8601String(),
+      'datetime': datetime.toIso8601String(),
     };
   }
 
@@ -119,7 +119,7 @@ class MicroAppEvent<T> extends EventChannelsEquatable {
       payload: map['payload'],
       distinct: map['distinct'] ?? false,
       version: map['version'],
-      timestamp: DateTime.tryParse(map['timestamp'] ?? '') ?? DateTime.now(),
+      datetime: DateTime.tryParse(map['datetime'] ?? '') ?? DateTime.now(),
       channels: channels,
     );
   }

--- a/lib/src/entities/micro_app_preferences.dart
+++ b/lib/src/entities/micro_app_preferences.dart
@@ -1,14 +1,20 @@
-import 'package:flutter_micro_app/flutter_micro_app.dart';
+import 'package:flutter/widgets.dart';
+
+import '../../flutter_micro_app.dart';
 
 final maAppBaseRoute = MicroAppPreferences.config.appBaseRoute.baseRoute.route;
 
 class MicroAppPreferences {
-  static MicroAppConfig config = MicroAppConfig(
-      nativeEventsEnabled: false,
-      pathSeparator: MicroAppPathSeparator.slash,
-      appBaseRoute: _DefaultBaseRoute());
-  static update(MicroAppConfig _config) {
-    config = _config;
+  static final ValueNotifier<MicroAppConfig> _config = ValueNotifier(
+      MicroAppConfig(
+          nativeEventsEnabled: false,
+          pathSeparator: MicroAppPathSeparator.slash,
+          appBaseRoute: _DefaultBaseRoute()));
+
+  static MicroAppConfig get config => _config.value;
+
+  static update(MicroAppConfig config) {
+    _config.value = config;
   }
 }
 

--- a/lib/src/infra/adapters/micro_app_event/micro_app_event_adapter.dart
+++ b/lib/src/infra/adapters/micro_app_event/micro_app_event_adapter.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/services.dart';
+
+import '../../../entities/events/micro_app_event.dart';
+
+abstract class MicroAppEventAdapter {
+  MicroAppEvent parse(MethodCall methodCall);
+}

--- a/lib/src/infra/adapters/micro_app_event/micro_app_event_json_adapter.dart
+++ b/lib/src/infra/adapters/micro_app_event/micro_app_event_json_adapter.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+
+import '../../../../dependencies.dart';
+import '../../../../flutter_micro_app.dart';
+import 'micro_app_event_adapter.dart';
+
+/// MethodCall arguments
+///
+/// Json example:
+/// ```json
+/// {
+///  "name": "", // Required
+///  "payload": {}, // Optional
+///  "distinct": true, // Optional
+///  "channels": [], // Optional
+///  "version": "1.0.0", // Optional
+///  "timestamp": "2020-01-01T00:00:00.000Z" // Optional
+/// }
+/// ```
+///
+/// If the json parse fails, it will return a default [MicroAppEvent]:
+/// ```dart
+/// return MicroAppEvent(
+///   name: methodCall.method,
+///   payload: methodCall.arguments,
+///   distinct: true,
+///   channels: [],
+///   timestamp: DateTime.now(),
+/// );
+/// ```
+class MicroAppEventJsonAdapter implements MicroAppEventAdapter {
+  @override
+  MicroAppEvent parse(MethodCall methodCall) {
+    try {
+      final map = jsonDecode(jsonEncode(methodCall.arguments as Object?));
+      final name = map['name'] ?? methodCall.method;
+      final payload = map['payload'];
+      final distinct = map['distinct'];
+      final version = map['version'];
+      final timestamp = map['timestamp'] != null
+          ? DateTime.tryParse(map['timestamp'] ?? '')
+          : null;
+
+      List<dynamic>? list = map['channels'];
+      final channels =
+          list != null ? list.map((e) => e.toString()).toList() : <String>[];
+
+      return MicroAppEvent(
+          name: name,
+          payload: payload,
+          distinct: distinct,
+          channels: channels,
+          version: version,
+          timestamp: timestamp);
+    } catch (e) {
+      logger.e('MicroAppEventJsonAdapter', error: e);
+      return MicroAppEvent(
+        name: methodCall.method,
+        payload: methodCall.arguments,
+      );
+    }
+  }
+}

--- a/lib/src/infra/adapters/micro_app_event/micro_app_event_json_adapter.dart
+++ b/lib/src/infra/adapters/micro_app_event/micro_app_event_json_adapter.dart
@@ -16,7 +16,7 @@ import 'micro_app_event_adapter.dart';
 ///  "distinct": true, // Optional
 ///  "channels": [], // Optional
 ///  "version": "1.0.0", // Optional
-///  "timestamp": "2020-01-01T00:00:00.000Z" // Optional
+///  "datetime": "2020-01-01T00:00:00.000Z" // Optional
 /// }
 /// ```
 ///
@@ -27,20 +27,23 @@ import 'micro_app_event_adapter.dart';
 ///   payload: methodCall.arguments,
 ///   distinct: true,
 ///   channels: [],
-///   timestamp: DateTime.now(),
+///   datetime: DateTime.now(),
 /// );
 /// ```
 class MicroAppEventJsonAdapter implements MicroAppEventAdapter {
   @override
   MicroAppEvent parse(MethodCall methodCall) {
     try {
-      final map = jsonDecode(jsonEncode(methodCall.arguments as Object?));
+      final type = methodCall.arguments.runtimeType;
+      final map = type == String
+          ? jsonDecode(methodCall.arguments)
+          : methodCall.arguments;
       final name = map['name'] ?? methodCall.method;
       final payload = map['payload'];
-      final distinct = map['distinct'];
+      final distinct = map['distinct'] ?? true;
       final version = map['version'];
-      final timestamp = map['timestamp'] != null
-          ? DateTime.tryParse(map['timestamp'] ?? '')
+      final datetime = map['datetime'] != null
+          ? DateTime.tryParse(map['datetime'] ?? '')
           : null;
 
       List<dynamic>? list = map['channels'];
@@ -53,7 +56,7 @@ class MicroAppEventJsonAdapter implements MicroAppEventAdapter {
           distinct: distinct,
           channels: channels,
           version: version,
-          timestamp: timestamp);
+          datetime: datetime);
     } catch (e) {
       logger.e('MicroAppEventJsonAdapter', error: e);
       return MicroAppEvent(

--- a/lib/src/presentation/widgets/micro_navigator_widget.dart
+++ b/lib/src/presentation/widgets/micro_navigator_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_micro_app/flutter_micro_app.dart';
-import 'package:flutter_micro_app/src/utils/mixins/router_generator_mixin.dart';
+
+import '../../entities/router/base_route.dart';
+import '../../utils/mixins/router_generator_mixin.dart';
 
 class MicroAppNavigatorWidget extends StatefulWidget {
   final MicroAppBaseRoute microBaseRoute;

--- a/lib/src/services/native_service.dart
+++ b/lib/src/services/native_service.dart
@@ -30,8 +30,8 @@ class MicroAppNativeService {
           error: e.message);
     } on PlatformException catch (e) {
       logger.e('Router Platform Error:', error: e.message);
-    } catch (e) {
-      logger.e('Critical Router Error', error: e);
+    } on Exception {
+      logger.e('Critical Router Error');
     }
 
     return null;

--- a/lib/src/services/native_service.dart
+++ b/lib/src/services/native_service.dart
@@ -2,6 +2,7 @@ import 'package:dart_log/dart_log.dart';
 import 'package:flutter/services.dart';
 
 import '../entities/micro_app_preferences.dart';
+import '../utils/constants/constants.dart';
 import '../utils/typedefs.dart';
 
 class MicroAppNativeService {
@@ -19,7 +20,11 @@ class MicroAppNativeService {
   MicroAppNativeService(this.channel, {this.methodCallHandler});
 
   Future<T?> emit<T>(String method, dynamic arguments) async {
-    if (!MicroAppPreferences.config.nativeEventsEnabled) return null;
+    if (!MicroAppPreferences.config.nativeEventsEnabled &&
+        method == Constants.methodMicroAppEvent) return null;
+    if (!MicroAppPreferences.config.nativeNavigationLogEnabled &&
+        method == Constants.methodNavigationLog) return null;
+
     try {
       return platform.invokeMethod(method, arguments);
     } on MissingPluginException catch (e) {
@@ -29,9 +34,9 @@ class MicroAppNativeService {
           'MicroAppPreferences.update(MicroAppPreferences.config.copyWith(nativeEventsEnabled: false));',
           error: e.message);
     } on PlatformException catch (e) {
-      logger.e('Router Platform Error:', error: e.message);
-    } on Exception {
-      logger.e('Critical Router Error');
+      logger.e('Platform Exception:', error: e.message);
+    } on Exception catch (e) {
+      logger.e('Critical Error', error: e);
     }
 
     return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_micro_app
 description: A package to speed up the creation of micro apps structure in Flutter applications
-version: 0.7.0
+version: 0.8.0
 homepage: https://github.com/emanuel-braz/flutter_micro_app
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   
   dart_log: ^1.1.1
-  equatable: ^2.0.3
+  equatable: 2.0.3
 
 dev_dependencies:
   flutter_test:

--- a/test/src/entities/events/micro_app_event_test.dart
+++ b/test/src/entities/events/micro_app_event_test.dart
@@ -16,7 +16,9 @@ void main() {
         'name': 'nome',
         'payload': 'abc',
         'distinct': true,
-        'channels': ['channel1', 'channel2']
+        'channels': ['channel1', 'channel2'],
+        'version': '1.0.0',
+        'timestamp': '2020-01-01T00:00:00.000Z'
       }));
 
       // assert
@@ -26,14 +28,41 @@ void main() {
       expect(eventFromJson?.payload, 'abc');
       expect(eventFromJson?.distinct, true);
       expect(eventFromJson?.type, equals(String));
+      expect(eventFromJson?.version, equals('1.0.0'));
+    });
+
+    test(
+        'Deve converter um json(String) válido em um MicroAppEvent<String> sem informar timestamp',
+        () {
+      // arrange
+      final eventFromJson = MicroAppEvent.fromJson(jsonEncode({
+        'name': 'nome',
+        'payload': 'abc',
+        'distinct': true,
+        'channels': ['channel1', 'channel2'],
+      }));
+
+      // assert
+      expect(eventFromJson, isA<MicroAppEvent>());
+      expect(eventFromJson?.channels.length, 2);
+      expect(eventFromJson?.name, 'nome');
+      expect(eventFromJson?.payload, 'abc');
+      expect(eventFromJson?.distinct, true);
+      expect(eventFromJson?.type, equals(String));
+      expect(eventFromJson?.version, equals(null));
     });
 
     test(
         'Deve converter um json válido, com lista de channels vazia, em um MicroAppEvent<int>',
         () {
       // arrange
-      final eventFromJson = MicroAppEvent.fromJson(jsonEncode(
-          {'name': 'nome', 'payload': 123, 'channels': [], 'distinct': false}));
+      final eventFromJson = MicroAppEvent.fromJson(jsonEncode({
+        'name': 'nome',
+        'payload': 123,
+        'channels': [],
+        'distinct': false,
+        'timestamp': '2020-01-01T00:00:00.000Z'
+      }));
 
       // assert
       expect(eventFromJson, isA<MicroAppEvent>());
@@ -41,6 +70,9 @@ void main() {
       expect(eventFromJson?.name, 'nome');
       expect(eventFromJson?.payload, 123);
       expect(eventFromJson?.type, equals(int));
+      expect(eventFromJson?.version, equals(null));
+      expect(eventFromJson?.timestamp,
+          equals(DateTime.parse('2020-01-01T00:00:00.000Z')));
     });
 
     test(
@@ -77,12 +109,13 @@ void main() {
   test('Deve retornar uma String com valores do MicroAppEvent, corretamente',
       () {
     // arrange
+    final timeStamp = DateTime.now();
     final event = MicroAppEvent(
-      name: 'nome',
-      payload: 'abc',
-      channels: const ['channel1', 'channel2'],
-      distinct: true,
-    );
+        name: 'nome',
+        payload: 'abc',
+        channels: const ['channel1', 'channel2'],
+        distinct: true,
+        timestamp: timeStamp);
 
     // act
     final eventAsString = event.toString();
@@ -91,7 +124,7 @@ void main() {
     expect(
         eventAsString,
         equals(
-            '{"name":"nome","payload":"abc","channels":["channel1","channel2"],"distinct":true}'));
+            '{"name":"nome","payload":"abc","channels":["channel1","channel2"],"distinct":true,"methodCall":"null","version":null,"timestamp":"${timeStamp.toIso8601String()}"}'));
   });
 
   test('Deve converter o MicroAppEvent em um Map<String, dynamic> corretamente',
@@ -106,17 +139,16 @@ void main() {
 
     // act
     final map = event.toMap();
-    final expectedResultMap = {
-      'name': 'nome',
-      'payload': 'abc',
-      'distinct': false,
-      'channels': ['channel1', 'channel2']
-    };
 
     // assert
-    expect(map, equals(expectedResultMap));
+    expect(map['name'], equals('nome'));
+    expect(map['payload'], equals('abc'));
+    expect(map['distinct'], equals(false));
+    expect(map['channels'], equals(['channel1', 'channel2']));
+    expect(map['version'], equals(null));
+
     expect(map, isA<Map<String, dynamic>>());
-    expect(map.length, equals(4));
+    expect(map.length, equals(6));
   });
 
   test('Deve fazer o cast do payload para String, corretamente', () {

--- a/test/src/entities/events/micro_app_event_test.dart
+++ b/test/src/entities/events/micro_app_event_test.dart
@@ -18,7 +18,7 @@ void main() {
         'distinct': true,
         'channels': ['channel1', 'channel2'],
         'version': '1.0.0',
-        'timestamp': '2020-01-01T00:00:00.000Z'
+        'datetime': '2020-01-01T00:00:00.000Z'
       }));
 
       // assert
@@ -32,7 +32,7 @@ void main() {
     });
 
     test(
-        'Deve converter um json(String) válido em um MicroAppEvent<String> sem informar timestamp',
+        'Deve converter um json(String) válido em um MicroAppEvent<String> sem informar datetime',
         () {
       // arrange
       final eventFromJson = MicroAppEvent.fromJson(jsonEncode({
@@ -49,7 +49,7 @@ void main() {
       expect(eventFromJson?.payload, 'abc');
       expect(eventFromJson?.distinct, true);
       expect(eventFromJson?.type, equals(String));
-      expect(eventFromJson?.version, equals(null));
+      expect(eventFromJson?.version, isNull);
     });
 
     test(
@@ -61,7 +61,7 @@ void main() {
         'payload': 123,
         'channels': [],
         'distinct': false,
-        'timestamp': '2020-01-01T00:00:00.000Z'
+        'datetime': '2020-01-01T00:00:00.000Z'
       }));
 
       // assert
@@ -70,8 +70,8 @@ void main() {
       expect(eventFromJson?.name, 'nome');
       expect(eventFromJson?.payload, 123);
       expect(eventFromJson?.type, equals(int));
-      expect(eventFromJson?.version, equals(null));
-      expect(eventFromJson?.timestamp,
+      expect(eventFromJson?.version, isNull);
+      expect(eventFromJson?.datetime,
           equals(DateTime.parse('2020-01-01T00:00:00.000Z')));
     });
 
@@ -109,13 +109,13 @@ void main() {
   test('Deve retornar uma String com valores do MicroAppEvent, corretamente',
       () {
     // arrange
-    final timeStamp = DateTime.now();
+    final datetime = DateTime.now();
     final event = MicroAppEvent(
         name: 'nome',
         payload: 'abc',
         channels: const ['channel1', 'channel2'],
         distinct: true,
-        timestamp: timeStamp);
+        datetime: datetime);
 
     // act
     final eventAsString = event.toString();
@@ -124,7 +124,7 @@ void main() {
     expect(
         eventAsString,
         equals(
-            '{"name":"nome","payload":"abc","channels":["channel1","channel2"],"distinct":true,"methodCall":"null","version":null,"timestamp":"${timeStamp.toIso8601String()}"}'));
+            '{"name":"nome","payload":"abc","channels":["channel1","channel2"],"distinct":true,"methodCall":null,"version":null,"datetime":"${datetime.toIso8601String()}"}'));
   });
 
   test('Deve converter o MicroAppEvent em um Map<String, dynamic> corretamente',
@@ -145,7 +145,7 @@ void main() {
     expect(map['payload'], equals('abc'));
     expect(map['distinct'], equals(false));
     expect(map['channels'], equals(['channel1', 'channel2']));
-    expect(map['version'], equals(null));
+    expect(map['version'], isNull);
 
     expect(map, isA<Map<String, dynamic>>());
     expect(map.length, equals(6));


### PR DESCRIPTION
### Summary (Feature / Bugfix description)
#### Break
- Using Map as default data transfer object, instead string

#### Fix
- Enable/disable native requets in navigation events

#### Added
- Parses event data from native platform

#### Bump
- version 0.8.0

#### This PR fixes/implements (types of changes)
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore, changes that do not affect the software behavior (docs, build process, configs, structures)

#### Requirements (if applicable)
- [x] Have you lint your code locally prior to submission?
- [x] All new and existing tests passed?
- [x] Did you update the changelog file?
- [x] Did you update pubspec.yaml?
- [x] Have you written new tests for your core changes, as applicable?