### PR TITLE
fix: route name not being set on ios, resulting in unnamed routes

### DIFF
--- a/lib/src/controllers/navigators/navigator_controller.dart
+++ b/lib/src/controllers/navigators/navigator_controller.dart
@@ -234,11 +234,13 @@ class MicroAppNavigatorController extends RouteObserver<PageRoute<dynamic>> {
         } else {
           if (isIOS) {
             return CupertinoPageRoute(
+              settings: RouteSettings(arguments: routeArguments, name: routeName),
               builder: (context) => pageBuilder.widgetBuilder!(context,
                   RouteSettings(arguments: routeArguments, name: routeName)),
             );
           } else {
             return MaterialPageRoute(
+              settings: RouteSettings(arguments: routeArguments, name: routeName),
               builder: (context) => pageBuilder.widgetBuilder!(context,
                   RouteSettings(arguments: routeArguments, name: routeName)),
             );


### PR DESCRIPTION
We noticed inconsistent behaviour between ios and android navigation.

For example when registering page:

```
 MicroAppPage(
          route: routes.initial,
          pageBuilder: PageBuilder(
            widgetBuilder: (context, settings) => const InitialPage(),
          ),
        ),
```

When registering route without custom MicroPageTransitionType route name is lost.
and cheking current route name always returns null on IOS.
Applied simple fix, I made sure route names are correctly initialized on IOS as well.  


 (flutter version 3.24.3)